### PR TITLE
Implement filter flash with tests

### DIFF
--- a/poc/bayesian_debiasing/src/filter_flash.py
+++ b/poc/bayesian_debiasing/src/filter_flash.py
@@ -1,0 +1,42 @@
+"""Consciousness-aware data filtering and flash event logic."""
+
+from typing import Any, Dict, List
+
+
+class FlashEventManager:
+    """Manage flash insight events."""
+
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    def trigger_insight_flash(self, pattern_recognition_event: Dict[str, Any]) -> Dict[str, Any]:
+        """Trigger an insight flash from a pattern recognition event."""
+        flash = {
+            "event": pattern_recognition_event,
+            "flash_triggered": True,
+        }
+        self.events.append(flash)
+        return flash
+
+
+class FilterFlash:
+    """Filter incoming data using a consciousness threshold."""
+
+    def __init__(self, consciousness_threshold: float = 0.5) -> None:
+        self.consciousness_threshold = consciousness_threshold
+        self.event_manager = FlashEventManager()
+
+    def filter_data(self, data: Any, cognitive_load: float = 0.0) -> Any:
+        """Filter data based on the current cognitive load."""
+        if cognitive_load > self.consciousness_threshold:
+            return []
+
+        if self._detect_pattern(data):
+            self.event_manager.trigger_insight_flash({"data": data})
+
+        return data
+
+    @staticmethod
+    def _detect_pattern(data: Any) -> bool:
+        """Simple pattern detection placeholder."""
+        return isinstance(data, dict) and data.get("pattern") is True

--- a/src/obiai/tests/unit/filter_flash/test_filter_flash.py
+++ b/src/obiai/tests/unit/filter_flash/test_filter_flash.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for filter_flash
+QA_LAYER: UNIT
+QA_STANDARD: PolyCore QA Validation Plan
+AEGIS_COMPLIANCE: Mathematical verification required
+"""
+
+import unittest
+from poc.bayesian_debiasing.src.filter_flash import FilterFlash, FlashEventManager
+
+
+class TestFilterFlash(unittest.TestCase):
+    """Unit tests for FilterFlash component"""
+
+    def setUp(self):
+        self.filter_flash = FilterFlash(consciousness_threshold=0.5)
+
+    def test_data_passes_filter(self):
+        """Data should pass when cognitive load is below threshold"""
+        data = {"value": 1}
+        result = self.filter_flash.filter_data(data, cognitive_load=0.3)
+        self.assertEqual(result, data)
+
+    def test_data_filtered_when_load_high(self):
+        """Data should be filtered out when load exceeds threshold"""
+        data = {"value": 1}
+        result = self.filter_flash.filter_data(data, cognitive_load=0.8)
+        self.assertEqual(result, [])
+
+    def test_flash_triggered_on_pattern(self):
+        """Pattern data should trigger an insight flash"""
+        data = {"pattern": True}
+        self.filter_flash.filter_data(data, cognitive_load=0.1)
+        self.assertEqual(len(self.filter_flash.event_manager.events), 1)
+        self.assertTrue(self.filter_flash.event_manager.events[0]["flash_triggered"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add consciousness-aware filtering logic and flash event manager
- implement trigger_insight_flash method
- test flash event logic and filter thresholds

## Testing
- `PYTHONPATH=src/obiai python -m unittest discover -s src/obiai/tests/unit/pattern_generator`
- `PYTHONPATH=src/obiai python -m unittest discover -s src/obiai/tests/unit/protective_barrier`
- `PYTHONPATH=src/obiai python -m unittest discover -s src/obiai/tests/unit/state_monitor`
- `PYTHONPATH=src/obiai python -m unittest discover -s src/obiai/tests/unit/epistemological_dag`
- `PYTHONPATH=src/obiai python -m unittest discover -s src/obiai/tests/unit/filter_flash`


------
https://chatgpt.com/codex/tasks/task_e_685f1879fc9083279c55f28b36e698de