### PR TITLE
Introduce VerbNounCapsule and integrate with DAG

### DIFF
--- a/src/obiai/obiai/core/__init__.py
+++ b/src/obiai/obiai/core/__init__.py
@@ -8,5 +8,6 @@ from .protective_barrier import *
 from .pattern_generator import *
 from .state_monitor import *
 from .epistemological_dag import *
+from .verb_noun_capsule import VerbNounCapsule
 
-__all__ = ['protective_barrier', 'pattern_generator', 'state_monitor', 'epistemological_dag']
+__all__ = ['protective_barrier', 'pattern_generator', 'state_monitor', 'epistemological_dag', 'VerbNounCapsule']

--- a/src/obiai/obiai/core/epistemological_dag/epistemological_dag.py
+++ b/src/obiai/obiai/core/epistemological_dag/epistemological_dag.py
@@ -6,6 +6,7 @@ Core feature logic following Aegis mathematical foundations
 import time
 from typing import Dict, Any, Optional
 from .epistemological_dag_config import get_config
+from ..verb_noun_capsule import VerbNounCapsule
 
 class Epistemological_dag:
     """
@@ -34,17 +35,21 @@ class Epistemological_dag:
             if key not in self.config:
                 raise ValueError(f"Missing required config key: {key}")
     
-    def process(self, data: Any) -> Dict[str, Any]:
-        """Primary processing method - implement feature-specific logic"""
+    def process(self, data: Any) -> Any:
+        """Create a verb-noun capsule from provided data."""
         if not self.initialized:
             raise RuntimeError(f"{self.__class__.__name__} not properly initialized")
-        
-        # Placeholder implementation
+
+        if isinstance(data, dict) and "verb" in data and "noun" in data:
+            context = data.get("context", {})
+            return VerbNounCapsule(data["verb"], data["noun"], context)
+
+        # Fallback to previous behaviour
         return {
             "status": "processed",
             "feature": self.config["feature_name"],
             "timestamp": time.time(),
-            "data_processed": True
+            "data_processed": True,
         }
     
     def validate_integrity(self) -> bool:

--- a/src/obiai/obiai/core/verb_noun_capsule.py
+++ b/src/obiai/obiai/core/verb_noun_capsule.py
@@ -1,0 +1,31 @@
+"""Verb-Noun knowledge capsule implementation."""
+
+from typing import Dict, Any, Optional
+import math
+
+
+class VerbNounCapsule:
+    """Representation of a verb-noun pair with cost and constraints."""
+
+    def __init__(self, verb: str, noun: str, context: Optional[Dict[str, Any]] = None):
+        self.action = verb
+        self.object = noun
+        self.context = context or {}
+        self.cost_weight = self.calculate_cost(verb, noun, self.context)
+        self.schema_constraints = self.derive_constraints(verb, noun)
+
+    def calculate_cost(self, verb: str, noun: str, context: Dict[str, Any]) -> float:
+        """Calculate conceptual cost using simple string metrics."""
+        verb_score = sum(ord(c) for c in verb)
+        noun_score = sum(ord(c) for c in noun)
+        diff = abs(verb_score - noun_score) / 1000.0
+        context_entropy = math.log(len(context) + 1, 2)
+        return diff + context_entropy
+
+    def derive_constraints(self, verb: str, noun: str) -> Dict[str, Any]:
+        """Derive basic schema constraints from the verb and noun."""
+        return {
+            "action_type": "dynamic" if verb.endswith("ing") else "static",
+            "object_required": noun.lower(),
+            "relationship": f"{verb}_{noun}",
+        }

--- a/src/obiai/tests/unit/epistemological_dag/test_epistemological_dag.py
+++ b/src/obiai/tests/unit/epistemological_dag/test_epistemological_dag.py
@@ -8,6 +8,7 @@ AEGIS_COMPLIANCE: Mathematical verification required
 import unittest
 from obiai.core.epistemological_dag.epistemological_dag import Epistemological_dag
 from obiai.core.epistemological_dag.epistemological_dag_config import get_config, get_zero_trust_config
+from obiai.core.verb_noun_capsule import VerbNounCapsule
 
 class TestEpistemological_dag(unittest.TestCase):
     """Unit tests for Epistemological_dag component"""
@@ -32,11 +33,11 @@ class TestEpistemological_dag(unittest.TestCase):
     def test_processing(self):
         """Test basic processing functionality"""
         component = Epistemological_dag(self.default_config)
-        result = component.process({'test': 'data'})
-        
-        self.assertIn('status', result)
-        self.assertEqual(result['status'], 'processed')
-        self.assertTrue(result['data_processed'])
+        capsule = component.process({'verb': 'run', 'noun': 'analysis', 'context': {'level': 1}})
+
+        self.assertIsInstance(capsule, VerbNounCapsule)
+        self.assertEqual(capsule.action, 'run')
+        self.assertEqual(capsule.object, 'analysis')
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/obiai/tests/unit/verb_noun_capsule/test_verb_noun_capsule.py
+++ b/src/obiai/tests/unit/verb_noun_capsule/test_verb_noun_capsule.py
@@ -1,0 +1,28 @@
+"""
+Unit tests for VerbNounCapsule
+QA_LAYER: UNIT
+QA_STANDARD: PolyCore QA Validation Plan
+AEGIS_COMPLIANCE: Mathematical verification required
+"""
+
+import unittest
+from obiai.core.verb_noun_capsule import VerbNounCapsule
+
+
+class TestVerbNounCapsule(unittest.TestCase):
+    """Unit tests for the VerbNounCapsule representation."""
+
+    def test_cost_and_constraints(self):
+        """Verify cost calculation and constraint derivation."""
+        capsule = VerbNounCapsule("running", "test", {"risk": 0.5})
+
+        self.assertEqual(capsule.action, "running")
+        self.assertEqual(capsule.object, "test")
+        self.assertIsInstance(capsule.cost_weight, float)
+        self.assertGreaterEqual(capsule.cost_weight, 0.0)
+        self.assertIn("action_type", capsule.schema_constraints)
+        self.assertEqual(capsule.schema_constraints["object_required"], "test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `VerbNounCapsule` for verb-noun reasoning
- expose the capsule class in `obiai.core`
- update `Epistemological_dag` to return a `VerbNounCapsule`
- test the new capsule and updated DAG behaviour

## Testing
- `PYTHONPATH=src/obiai pytest -q src/obiai/tests --override-ini addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_685f18794a108327952b6a0b66ed72f4